### PR TITLE
短信发送成功与否的判断方式改为解析响应字符串的 code 判断

### DIFF
--- a/src/main/java/ink/verge/yiban_auto_checkin/service/impl/SmsServiceImpl.java
+++ b/src/main/java/ink/verge/yiban_auto_checkin/service/impl/SmsServiceImpl.java
@@ -8,6 +8,7 @@ import ink.verge.yiban_auto_checkin.service.RedisService;
 import ink.verge.yiban_auto_checkin.service.SmsService;
 import ink.verge.yiban_auto_checkin.utils.CreateCodeUtil;
 import ink.verge.yiban_auto_checkin.utils.SmsUtil;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,8 +65,10 @@ public class SmsServiceImpl implements SmsService {
         logger.info("验证码：" + smsCode.getCode());
         logger.info("encode:" + smsCode.getCode());
         smsCode.encode();
-        if (!smsUtil.sendSms(modelName, paramMap, telephone)) {
-            throw new BusinessException(EmBusinessError.EMAIL_SEND_FAILURE);
+        String sendCode = smsUtil.sendSms(modelName, paramMap, telephone);
+        if (!StringUtils.equals(sendCode, "OK")) {
+            throw new BusinessException(EmBusinessError.SMS_SEND_FAILED,
+                    "短信发送失败，CODE: " + sendCode);
         }
         switch (modelId) {
             case 0:

--- a/src/main/java/ink/verge/yiban_auto_checkin/utils/SmsUtil.java
+++ b/src/main/java/ink/verge/yiban_auto_checkin/utils/SmsUtil.java
@@ -1,5 +1,7 @@
 package ink.verge.yiban_auto_checkin.utils;
 
+import cn.hutool.json.JSONObject;
+import cn.hutool.json.JSONUtil;
 import com.alibaba.druid.support.json.JSONUtils;
 import com.aliyuncs.CommonRequest;
 import com.aliyuncs.CommonResponse;
@@ -8,7 +10,10 @@ import com.aliyuncs.IAcsClient;
 import com.aliyuncs.exceptions.ClientException;
 import com.aliyuncs.http.MethodType;
 import com.aliyuncs.profile.DefaultProfile;
+import com.fehead.lang.error.BusinessException;
+import com.fehead.lang.error.EmBusinessError;
 import com.fehead.lang.properties.FeheadProperties;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.Resource;
@@ -38,6 +43,7 @@ import java.util.Map;
 @Component
 public class SmsUtil {
 
+    private static final String ORDINARY_ERROR = "CLIENT_SEND_FAILED";
     @Resource
     private FeheadProperties feheadProperties;
 
@@ -48,9 +54,9 @@ public class SmsUtil {
      * @param modelName  短信模板名，传入的模板必须是在阿里大于“管理中心-短信模板管理”中的可用模板。示例：sms.TemplateNotice
      * @param modelParam 模板内容里面的变量
      * @param phone      用户手机号码
-     * @return boolean true成功false失败
+     * @return String    Code
      */
-    public boolean sendSms(String modelName, Map<String, String> modelParam, String phone) {
+    public String sendSms(String modelName, Map<String, String> modelParam, String phone) {
 
         String appKey = feheadProperties.getSmsProperties().getAppKey();
         String secret = feheadProperties.getSmsProperties().getSecret();
@@ -73,14 +79,15 @@ public class SmsUtil {
         request.putQueryParameter("TemplateCode", modelName);
         request.putQueryParameter("TemplateParam", JSONUtils.toJSONString(modelParam));
         System.out.println("modelParam: " + JSONUtils.toJSONString(modelParam));
+        JSONObject data;
         try {
             CommonResponse response = client.getCommonResponse(request);
-            System.out.println(response.getData());
+            data = JSONUtil.parseObj(response.getData());
         } catch (ClientException e) {
             e.printStackTrace();
-            return false;
+            return ORDINARY_ERROR;
         }
-
-        return true;
+        System.out.println(data);
+        return (String) data.get("Code");
     }
 }


### PR DESCRIPTION
修改了一下 SmsUtils 的成功判断逻辑
1. 调用短信服务 api 失败时会返回 ”CLIENT_SEND_FAILED“
2. 调用短信服务 api 成功时返回响应参数中的 Code，成功 Code 为 ”OK“，失败参考阿里云短信服务 API 错误码

相应修改了 SmsServiceImpl 的相关逻辑